### PR TITLE
new public variant of the model for scaling law extraction

### DIFF
--- a/datasets/Large_500k_SAT_11_15_marginal_large/dat_split.py
+++ b/datasets/Large_500k_SAT_11_15_marginal_large/dat_split.py
@@ -1,0 +1,36 @@
+import os
+import random
+
+# Define paths
+cur_path = os.path.dirname(os.path.realpath(__file__))
+data_file_path = os.path.join(cur_path, "SAT_11_15_random_large.txt")
+train_file_path = os.path.join(cur_path, "train.txt")
+test_file_path = os.path.join(cur_path, "test.txt")
+
+# Parameters for splitting
+test_size = 0.2  
+random_seed = 42 
+
+# Load the data
+with open(data_file_path, 'r') as file:
+    data = file.readlines()
+
+# Shuffle data with a fixed seed for consistency
+random.seed(random_seed)
+random.shuffle(data)
+
+# Split the data
+split_index = int(len(data) * (1 - test_size))
+train_data = data[:split_index]
+test_data = data[split_index:]
+
+# Save the split data
+with open(train_file_path, 'w') as file:
+    file.writelines(train_data)
+
+with open(test_file_path, 'w') as file:
+    file.writelines(test_data)
+
+print(f"Data split into {len(train_data)} training samples and {len(test_data)} testing samples.")
+print(f"Training data saved to: {train_file_path}")
+print(f"Testing data saved to: {test_file_path}")

--- a/gpt_train.py
+++ b/gpt_train.py
@@ -1,50 +1,34 @@
+import os
 import torch
 from torch.utils.data import Dataset, DataLoader, random_split
 from torch.profiler import profile, record_function, ProfilerActivity
-
-from transformers import (AutoModel,
-                          GPT2Config,
-                          GPT2LMHeadModel,
-                          GPT2Model,
-                          LlamaConfig,
-                          LlamaForCausalLM,
-                          PreTrainedTokenizer,
-                          Trainer,
-                          TrainingArguments,
-                          get_linear_schedule_with_warmup,
+from transformers import (AutoModel, GPT2Config, GPT2LMHeadModel, GPT2Model,
+                          LlamaConfig, LlamaForCausalLM, PreTrainedTokenizer,
+                          Trainer, TrainingArguments, get_linear_schedule_with_warmup,
                           get_cosine_schedule_with_warmup)
-
 from torch.optim import AdamW
-
-
 from sat_dataset import SATDataset, CustomTokenizer
 from sat_trainer import SATHFTrainer
-from utils import get_dataset_path
 import utils
 import time
-import os
 
 ### Parameters ###
 epochs = 20
 batch_size = 12
 block_size = 800
 max_id = 30
-out_dir = 'models/sat-gpt'
-dataset = None
+out_dir = 'models/sat-llama'
 debug = False
 append_timestamp = True
 use_wandb = True
 remove_trace = False
-n_layer = 12
-n_embd = 768
-n_head = 12
 rand_pos = True
 perm_vars = True
 load_model = None
 old_tokenizer = False
-state_trace = False
+state_trace = True
 mask_formula = True
-model = "gpt2"
+model = "llama"
 ##################
 
 exec(open('configurator.py').read())
@@ -53,20 +37,24 @@ utils.debug = debug
 if debug:
     use_wandb = False
 
-if dataset is None:
-    raise ValueError("Please specify a dataset by setting the 'dataset' variable in the config file or using --dataset=[DATASET PATH].")
+# Llama model sizes (up to 7B)
+llama_sizes = {
+    "llama-70M": {"n_layer": 6, "n_embd": 512, "n_head": 8},
+    "llama-160M": {"n_layer": 12, "n_embd": 768, "n_head": 12},
+    "llama-410M": {"n_layer": 24, "n_embd": 1024, "n_head": 16},
+    "llama-1B": {"n_layer": 24, "n_embd": 2048, "n_head": 32},
+    "llama-3B": {"n_layer": 32, "n_embd": 3200, "n_head": 32},
+    "llama-7B": {"n_layer": 32, "n_embd": 4096, "n_head": 32},
+}
 
 # To prevent overwriting existing models
 if append_timestamp:
     out_dir += f"-{time.strftime('%Y%m%d-%H%M%S')}"
 
-if debug:
-    out_dir = "temp"
 
-if old_tokenizer:
-    custom_tokens = [str(i) for i in range(30 + 1)] + ["-", "[SEP]", "SAT", "UNSAT", "[EOS]", "[UNK]", "(", ")"]
-elif state_trace:
-    custom_tokens = [str(i) for i in range(30 + 1)] + [str(-i) for i in range(1, 30 + 1)] + ["[SEP]", "SAT", "UNSAT", "[EOS]","|", "Decide", "UP", "D", "BackTrack", "[UNK]"]
+# remove | "bar" and UP = [ , BACK 
+if state_trace:                                                                                              
+    custom_tokens = [str(i) for i in range(30 + 1)] + [str(-i) for i in range(1, 30 + 1)] + ["[SEP]", "SAT", "UNSAT", "[EOS]", "Decide", "[UP]", "D", "[BT]", "[UNK]"]
 else:
     custom_tokens = [str(i) for i in range(30 + 1)] + [str(-i) for i in range(1, 30 + 1)] + ["[SEP]", "SAT", "UNSAT", "[EOS]", "[UNK]", "(", ")"]
 
@@ -75,98 +63,76 @@ print("Token Set:", custom_tokens)
 # Initialize custom tokenizer
 tokenizer = CustomTokenizer(custom_tokens)
 
-if model == "gpt2":
-    # Initialize GPT-2 configuration
-    config = GPT2Config(vocab_size=len(tokenizer.vocab),
-                        n_ctx=block_size,
-                        n_embd=n_embd,
-                        n_layer=n_layer,
-                        n_head=n_head,
-                        n_positions=block_size,
-                        bos_token_id=tokenizer.vocab["[EOS]"],
-                        eos_token_id=tokenizer.vocab["[EOS]"],
-                    )
+# Update the path to the local dataset directory
+data_directory = "./datasets/Large_500k_SAT_11_15_marginal_large/"
 
-    # Initialize GPT-2 model
-    model = GPT2LMHeadModel(config)
+# Load the training data from the local file
+train_file_path = os.path.join(data_directory, "train.txt")
 
-    total_params = sum(p.numel() for p in model.parameters())
-    print(f"Total Parameters: {total_params}")
+# Custom code to read the local dataset file
+with open(train_file_path, 'r') as train_file:
+    train_data = train_file.readlines()
 
-    if load_model is not None:
-        model = GPT2LMHeadModel.from_pretrained(load_model)
-
-elif model == "llama":
-
-    if load_model is not None:
-        model = LlamaForCausalLM.from_pretrained(load_model)
-    else:
-        # For RoPE Encoding
-        config = LlamaConfig(vocab_size=len(tokenizer.vocab),
-                            max_position_embeddings=block_size,
-                            num_hidden_layers=n_layer,
-                            num_attention_heads=n_head,
-                            hidden_size=n_embd,
-                            intermediate_size=4 * n_embd, # Where did 11008 even come from?
-                            bos_token_id=tokenizer.vocab["[EOS]"],
-                            eos_token_id=tokenizer.vocab["[EOS]"],
-                            )
-
-        model = LlamaForCausalLM(config)
-
-else:
-    raise ValueError("Invalid model type. Please choose either 'gpt2' or 'llama'.")
-
-
-
-# Load dataset
-dataset_path = get_dataset_path(dataset)
-dataset = SATDataset(file_path=dataset_path,
-                    tokenizer=tokenizer,
-                    max_id=max_id,
-                    block_size=block_size,
-                    remove_trace=remove_trace,
-                    shift_within_block=rand_pos,
-                    permute_constants=perm_vars,
-                    mask_formula=mask_formula,
-                    old_tokenizer=old_tokenizer)
-
+# Instantiate the SATDataset
+custom_dataset = SATDataset(train_file_path,  # Pass the file path
+                            tokenizer=tokenizer,
+                            max_id=max_id,
+                            block_size=block_size,
+                            remove_trace=remove_trace,
+                            shift_within_block=rand_pos,
+                            permute_constants=perm_vars,
+                            mask_formula=mask_formula)
 
 # Split the dataset into training and validation sets
-train_size = int(0.9 * len(dataset))
-val_size = len(dataset) - train_size
-train_dataset, val_dataset = random_split(dataset, [train_size, val_size])
+train_size = int(0.9 * len(custom_dataset))
+val_size = len(custom_dataset) - train_size
+train_dataset, val_dataset = random_split(custom_dataset, [train_size, val_size])
 
-# Training arguments with evaluation strategy and save strategy
-training_args = TrainingArguments(
-    output_dir=out_dir,
-    num_train_epochs=epochs,
-    per_device_train_batch_size=batch_size,
-    logging_steps=100,
-    save_steps=500,
-    eval_steps=500,
-    evaluation_strategy="steps",
-    save_total_limit=2,
-    load_best_model_at_end=True,
-    metric_for_best_model="loss",
-    greater_is_better=False,
-    report_to="wandb" if use_wandb else "none",
-    run_name=os.path.basename(out_dir)
-)
-
-# Initialize Trainer with train and validation datasets
-trainer = SATHFTrainer(model=model,
-                         args=training_args,
-                         train_dataset=train_dataset,
-                         eval_dataset=val_dataset,
+# Loop over each model size and train
+for model_name, model_config in llama_sizes.items():
+    print(f"Training {model_name}")
+    
+    config = LlamaConfig(vocab_size=len(tokenizer.vocab),
+                         max_position_embeddings=block_size,
+                         num_hidden_layers=model_config["n_layer"],
+                         num_attention_heads=model_config["n_head"],
+                         hidden_size=model_config["n_embd"],
+                         intermediate_size=4 * model_config["n_embd"],
+                         bos_token_id=tokenizer.vocab["[EOS]"],
+                         eos_token_id=tokenizer.vocab["[EOS]"],
                         )
 
-# Train the model
-if load_model:
-    trainer.train(resume_from_checkpoint=load_model)
-else:
+    model = LlamaForCausalLM(config)
+
+    # Training arguments with evaluation strategy and save strategy
+    training_args = TrainingArguments(
+        output_dir=f"{out_dir}-{model_name}",
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
+        logging_steps=100,
+        save_steps=500,
+        eval_steps=500,
+        evaluation_strategy="steps",
+        save_total_limit=2,
+        load_best_model_at_end=True,
+        metric_for_best_model="loss",
+        greater_is_better=False,
+        report_to="wandb" if use_wandb else "none",
+        run_name=f"{os.path.basename(out_dir)}-{model_name}"
+    )
+
+    # Initialize Trainer with train and validation datasets
+    trainer = SATHFTrainer(model=model,
+                           args=training_args,
+                           train_dataset=train_dataset,
+                           eval_dataset=val_dataset,
+                          )
+
+    # Train the model
     trainer.train()
 
-# Save the final model and tokenizer
-model.save_pretrained(out_dir)
-tokenizer.save_pretrained(out_dir)
+    # Save the final model and tokenizer
+    model.save_pretrained(f"{out_dir}-{model_name}")
+    tokenizer.save_pretrained(f"{out_dir}-{model_name}")
+
+print("Training completed for all model sizes.")

--- a/sat_dataset.py
+++ b/sat_dataset.py
@@ -133,7 +133,11 @@ class SATDataset(Dataset):
             # first get length of unmasked input and determine how much left
             # padding is needed
             input_len = torch.sum(attention_mask)
-            size_left_pad = torch.randint(high=(block_size - input_len), size=(1,)).item()
+            #size_left_pad = torch.randint(high=(block_size - input_len), size=(1,)).item()
+            if block_size > input_len:
+                size_left_pad = torch.randint(high=(block_size - input_len), size=(1,)).item()
+            else:
+                size_left_pad = 0  # or handle this case appropriately
 
             input_ids = self.left_pad(input_ids, size_left_pad, self.tokenizer.pad_token_id, block_size)
             labels = self.left_pad(labels, size_left_pad, -100, block_size)


### PR DESCRIPTION
Summary
This PR addresses is a facsimile of the commit made in the private repos and is also housed in our Google Drive environment 

Changes:
Delta from Google Drive Variant - No "driver" notebook that acts as a importu terminal. 
Delta from Private Repos - None

Actions: 
GPT_train was modified to include definitions I extracted on different model sized I found online for Llama3 procurred from HF. Invoking the script via python gpt_train.py will execute the process, and if left alone it will sequentially go about training all model sizes from smallest to largest. I did this as a test just to see if it could run, as I had also fixed a few issues with the left_pad in SAT_training and altering SAT_trainer.py. 

Reasoning: We need to see if we can create a statistical regression to detect scaling laws. 

Testing:
I have run this script in both on-premises boxes, PACE, and Google Colab+ Premium. It works on all 3 but the run-time projected by W&B for all 3 tended to be 40+ hours (see W&B artifacts for the runs - though I hadn't reintroduced W&B API in the PACE runs as this was the first to be run). 

Next steps: 
Implement any run-time reducing codes (this planning/thinking/strategizing this at the moment), then run in concurrent jobs across all our environemnts. 